### PR TITLE
Streaming Tokenization

### DIFF
--- a/cmd/dataset_tokenizer/dataset_tokenizer.go
+++ b/cmd/dataset_tokenizer/dataset_tokenizer.go
@@ -79,7 +79,7 @@ func (runeReader SanitizedRuneReader) nextLine() bool {
 	lines := strings.Split(text, "\n")
 	for lineIdx := range lines {
 		line := lines[lineIdx]
-		text = runeReader.whitespaceRegex.ReplaceAllString(text, " ")
+		line = runeReader.whitespaceRegex.ReplaceAllString(line, " ")
 		line = strings.TrimSpace(line)
 		lines[lineIdx] = line
 	}

--- a/cmd/dataset_tokenizer/dataset_tokenizer_test.go
+++ b/cmd/dataset_tokenizer/dataset_tokenizer_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -41,6 +42,24 @@ func TestSanitizer(t *testing.T) {
 	for testIdx := range sanitizerTests {
 		input := sanitizerTests[testIdx].Input
 		output := SanitizeText(input)
+		assert.Equal(t, sanitizerTests[testIdx].Expected, output)
+	}
+}
+
+func TestSanitizedRuneReader_ReadRune(t *testing.T) {
+	for testIdx := range sanitizerTests {
+		input := sanitizerTests[testIdx].Input
+		reader := CreateTextSanitizer(bytes.NewBufferString(input))
+		runes := make([]rune, 0)
+		for {
+			r, size, _ := reader.ReadRune()
+			if size > 0 {
+				runes = append(runes, r)
+			} else {
+				break
+			}
+		}
+		output := string(runes)
 		assert.Equal(t, sanitizerTests[testIdx].Expected, output)
 	}
 }

--- a/cmd/dataset_tokenizer/sanitizer.go
+++ b/cmd/dataset_tokenizer/sanitizer.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"regexp"
+	"strings"
+)
+
+type SanitizedRuneReader struct {
+	bufSize         int
+	lastRune        *rune
+	whitespaceRegex *regexp.Regexp
+	reader          *bufio.Reader
+	currBuffer      **bytes.Buffer
+	accumulator     *[]rune
+	accumulatorIdx  *int
+	moreBuffers     chan *bytes.Buffer
+}
+
+func (runeReader SanitizedRuneReader) nextBuffer() *bytes.Buffer {
+	acc := runeReader.accumulator
+	accIdx := runeReader.accumulatorIdx
+	idx := *accIdx
+	var text string
+	for {
+		if idx > runeReader.bufSize {
+			text = string((*acc)[:runeReader.bufSize])
+			(*acc)[0] = (*acc)[idx-1]
+			*accIdx = 1
+			break
+		}
+		r, size, _ := (*runeReader.reader).ReadRune()
+		if size == 0 && idx == 0 {
+			// No valid rune, and our accumulator is empty, so we're done.
+			return nil
+		} else if size == 0 {
+			// No valid rune, and we have stuff in our accumulator, so let's
+			// flush and finish up.
+			text = string((*acc)[:*accIdx])
+			*accIdx = 0
+			break
+		} else if r == '\r' {
+			// Silently drop Windows `\r`
+		} else if r == '\n' && *runeReader.lastRune == '\n' {
+			// Drop additional newlines.
+		} else if r == 'n' && *runeReader.lastRune == '\\' {
+			// Replace escaped `\n` with `\n`.
+			(*acc)[idx-1] = '\n'
+		} else if r == ':' && *runeReader.lastRune == ' ' {
+			// Strip colons with leading spaces.
+			(*acc)[idx-1] = ':'
+		} else if r == '\t' {
+			// Replace tabs with single spaces.
+			(*acc)[idx] = ' '
+			idx++
+		} else {
+			// We have a valid rune, so let's insert it onto our accumulator.
+			(*acc)[idx] = r
+			idx++
+		}
+		*runeReader.lastRune = (*acc)[idx-1]
+	}
+	lines := strings.Split(text, "\n")
+	for lineIdx := range lines {
+		line := lines[lineIdx]
+		line = runeReader.whitespaceRegex.ReplaceAllString(line, " ")
+		line = strings.TrimSpace(line)
+		lines[lineIdx] = line
+	}
+	text = strings.Join(lines, "\n")
+	stringBuffer := bytes.NewBufferString(text)
+	return stringBuffer
+}
+
+func (runeReader SanitizedRuneReader) ReadRune() (r rune, size int,
+	err error) {
+	if *runeReader.currBuffer == nil {
+		return 0, 0, io.EOF
+	} else if r, size, err = (*runeReader.currBuffer).ReadRune(); err != nil {
+		if newBuffer, ok := <-runeReader.moreBuffers; !ok {
+			return 0, 0, io.EOF
+		} else {
+			*runeReader.currBuffer = newBuffer
+			return (*runeReader.currBuffer).ReadRune()
+		}
+	} else {
+		return r, size, err
+	}
+}
+
+func CreateTextSanitizer(handle io.Reader) SanitizedRuneReader {
+	extraWhiteSpace := regexp.MustCompile("[[:space:]]+")
+	scanner := bufio.NewReader(handle)
+	accumulator := make([]rune, 32769, 32769)
+	emptyBuffer := bytes.NewBufferString("")
+	lastRune := rune(0)
+	accumlatorIdx := 0
+	sanitizer := SanitizedRuneReader{
+		bufSize:         32768,
+		lastRune:        &lastRune,
+		whitespaceRegex: extraWhiteSpace,
+		reader:          scanner,
+		accumulator:     &accumulator,
+		accumulatorIdx:  &accumlatorIdx,
+		currBuffer:      &emptyBuffer,
+		moreBuffers:     make(chan *bytes.Buffer, 1),
+	}
+	nextBuffer := sanitizer.nextBuffer()
+	sanitizer.currBuffer = &nextBuffer
+	go func() {
+		for {
+			if newBuffer := sanitizer.nextBuffer(); newBuffer == nil {
+				close(sanitizer.moreBuffers)
+				break
+			} else {
+				sanitizer.moreBuffers <- newBuffer
+			}
+		}
+	}()
+	return sanitizer
+}
+
+func SanitizeText(text string) string {
+	reader := CreateTextSanitizer(bytes.NewBufferString(text))
+	runes := make([]rune, 0)
+	for {
+		r, size, _ := reader.ReadRune()
+		if size > 0 {
+			runes = append(runes, r)
+		} else {
+			break
+		}
+	}
+	return string(runes)
+}

--- a/gpt_bpe_test.go
+++ b/gpt_bpe_test.go
@@ -206,13 +206,12 @@ var SplitTests = []SplitTest{
 		[]string{"\n", "starting", " with", " multilines",
 			"\n", "is", " awesome"}}}
 
-/*
 func TestGPTEncoder_Split(t *testing.T) {
 	for testIdx := range SplitTests {
 		test := SplitTests[testIdx]
-		assert.Equal(t, *(gpt2Encoder.SplitWords(&test.Input)), test.Expected)
+		assert.Equal(t, test.Expected, *(gpt2Encoder.SplitWords(&test.Input)))
 	}
-}*/
+}
 
 func BenchmarkGPTEncoder_Decode(b *testing.B) {
 	if gpt2Encoded == nil {
@@ -270,7 +269,8 @@ func TestGPTEncoder_Encode(t *testing.T) {
 
 func TestGPTEncoder_StreamingEncode(t *testing.T) {
 	start := time.Now()
-	nextTokens := gpt2Encoder.StreamingEncode(&corpus)
+	corpusRunes := strings.NewReader(corpus)
+	nextTokens := gpt2Encoder.StreamingEncode(corpusRunes)
 	tokenCt := 0
 	for {
 		tokens := nextTokens(16384)

--- a/resources/resolver.go
+++ b/resources/resolver.go
@@ -141,8 +141,9 @@ func Fetch(uri string, rsrc string) (io.ReadCloser, error) {
 		return FetchHTTP(uri, rsrc)
 	} else if _, err := os.Stat(path.Join(uri, rsrc)); !os.IsNotExist(err) {
 		if handle, fileErr := os.Open(path.Join(uri, rsrc)); fileErr != nil {
-			return nil, errors.New(fmt.Sprintf("error opening %s/%s",
-				fileErr))
+			return nil, errors.New(
+				fmt.Sprintf("error opening %s/%s: %v",
+					uri, rsrc, fileErr))
 		} else {
 			return handle, fileErr
 		}
@@ -292,7 +293,7 @@ func ResolveResources(uri string, dir *string,
 				if skipFileErr != nil {
 					return &foundResources, errors.New(
 						fmt.Sprintf("error opening '%s' for write: %s",
-							rsrcFile, skipFileErr))
+							file, skipFileErr))
 				} else {
 					rsrcFile = *openFile
 				}
@@ -309,7 +310,7 @@ func ResolveResources(uri string, dir *string,
 				if rsrcFileErr != nil {
 					return &foundResources, errors.New(
 						fmt.Sprintf("error opening '%s' for write: %s",
-							rsrcFile, rsrcFileErr))
+							file, rsrcFileErr))
 				}
 				counter := &WriteCounter{
 					Last: time.Now(),
@@ -322,7 +323,7 @@ func ResolveResources(uri string, dir *string,
 				if ioErr != nil {
 					return &foundResources, errors.New(
 						fmt.Sprintf("error downloading '%s': %s",
-							rsrcFile, ioErr))
+							file, ioErr))
 				} else {
 					log.Println(fmt.Sprintf("Downloaded %s/%s... "+
 						"%s completed.", uri, file,


### PR DESCRIPTION
Clocks in at `~1.8mm` tokens per second on ~3 CPU cores.
* Sanitizer thread that does some data cleanup in a streaming fashion
* Tokenization thread
* Chunker and context alignment thread

Took no more than `80mb` resident RAM.