### PR TITLE
LRU optimizations and reporting. toBPE now returns token ids rather than strings.

### DIFF
--- a/cmd/dataset_tokenizer/go.mod
+++ b/cmd/dataset_tokenizer/go.mod
@@ -2,9 +2,11 @@ module github.com/wbrown/gpt_bpe/cmd/dataset_tokenizer
 
 go 1.18
 
+replace github.com/wbrown/gpt_bpe => ../../
+
 require (
 	github.com/stretchr/testify v1.7.1
-	github.com/wbrown/gpt_bpe v0.0.0-20220930153931-0b11191f2f74
+	github.com/wbrown/gpt_bpe v0.0.0-20221219163200-f4def400a5c4
 	github.com/yargevad/filepathx v1.0.0
 )
 
@@ -18,7 +20,7 @@ require (
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mingrammer/commonregex v1.0.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/sys v0.0.0-20221013171732-95e765b1cc43 // indirect
+	golang.org/x/sys v0.3.0 // indirect
 	gonum.org/v1/gonum v0.12.0 // indirect
 	gopkg.in/neurosnap/sentences.v1 v1.0.7 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect

--- a/cmd/dataset_tokenizer/go.sum
+++ b/cmd/dataset_tokenizer/go.sum
@@ -41,6 +41,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/wbrown/gpt_bpe v0.0.0-20220930153931-0b11191f2f74 h1:NoUrxk3F3szLwSKsxVTXn0jWSgy5sDPfDo4xa+brSC4=
 github.com/wbrown/gpt_bpe v0.0.0-20220930153931-0b11191f2f74/go.mod h1:VVaSEgWikVF7ft8riYPC+XBgjYhe1HFsnerDkjL3yMo=
+github.com/wbrown/gpt_bpe v0.0.0-20221219163200-f4def400a5c4 h1:uLmweqilspLFFIwKlNFNOtSrQdwFQ5QP6BVbBqgCLCA=
+github.com/wbrown/gpt_bpe v0.0.0-20221219163200-f4def400a5c4/go.mod h1:VVaSEgWikVF7ft8riYPC+XBgjYhe1HFsnerDkjL3yMo=
 github.com/yargevad/filepathx v1.0.0 h1:SYcT+N3tYGi+NvazubCNlvgIPbzAk7i7y2dwg3I5FYc=
 github.com/yargevad/filepathx v1.0.0/go.mod h1:BprfX/gpYNJHJfc35GjRRpVcwWXS89gGulUIU5tK3tA=
 golang.org/x/exp v0.0.0-20180321215751-8460e604b9de/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -50,6 +52,8 @@ golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfU
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/sys v0.0.0-20221013171732-95e765b1cc43 h1:OK7RB6t2WQX54srQQYSXMW8dF5C6/8+oA/s5QBmmto4=
 golang.org/x/sys v0.0.0-20221013171732-95e765b1cc43/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.3.0 h1:w8ZOecv6NaNa/zC8944JTU3vz4u6Lagfk4RPQxv92NQ=
+golang.org/x/sys v0.3.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/tools v0.0.0-20180525024113-a5b4c53f6e8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190206041539-40960b6deb8e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gonum.org/v1/gonum v0.0.0-20180816165407-929014505bf4/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=


### PR DESCRIPTION
* Switch to ARC caching
* Increase cache to 64k slots.
* LRU cache tracking
* `toBPE` now returns `Tokens` rather than `[]string` so that the translation from bigram `string` into `Token` is also cached.