### PR TITLE
Clean up reporting of inputs a bit, report tokenizer and inputs.

### DIFF
--- a/cmd/dataset_tokenizer/dataset_tokenizer.go
+++ b/cmd/dataset_tokenizer/dataset_tokenizer.go
@@ -626,8 +626,10 @@ func main() {
 		log.Fatal("Sampling parameter out of the 0-100 bounds")
 	}
 
-	fmt.Printf("Selected Tokenizer Reordering method: %s\n", *reorderPaths)
-	fmt.Printf("Selected Sampling amount (in %% tokens kept): %d\n", sampling)
+	log.Printf("Tokenizer definition: %s\n", *tokenizerId)
+	log.Printf("Tokenizer output: %s\n", *outputFile)
+	log.Printf("Tokenizer reordering method: %s\n", *reorderPaths)
+	log.Printf("Sampling amount (in % tokens kept): %d%\n", sampling)
 
 	if *reorderPaths != "" {
 		if *reorderPaths != "size_ascending" &&

--- a/cmd/dataset_tokenizer/dataset_tokenizer.go
+++ b/cmd/dataset_tokenizer/dataset_tokenizer.go
@@ -627,6 +627,7 @@ func main() {
 	}
 
 	log.Printf("Tokenizer definition: %s\n", *tokenizerId)
+        log.Printf("Tokenizer input source: %s\n", *inputDir)
 	log.Printf("Tokenizer output: %s\n", *outputFile)
 	log.Printf("Tokenizer reordering method: %s\n", *reorderPaths)
 	log.Printf("Sampling amount (in % tokens kept): %d%\n", sampling)

--- a/resources/resolver.go
+++ b/resources/resolver.go
@@ -84,8 +84,8 @@ func GetResourceEntries(typ ResourceType) ResourceEntryDefs {
 	case RESOURCETYPE_TRANSFORMERS:
 		return ResourceEntryDefs{
 			"config.json":             RESOURCE_REQUIRED,
-			"vocab.json":              RESOURCE_REQUIRED,
-			"merges.txt":              RESOURCE_REQUIRED,
+			"vocab.json":              RESOURCE_OPTIONAL,
+			"merges.txt":              RESOURCE_OPTIONAL,
 			"special_tokens_map.json": RESOURCE_OPTIONAL,
 			"unitrim.json":            RESOURCE_OPTIONAL,
 			"wordtokens.json":         RESOURCE_OPTIONAL,

--- a/resources/resolver.go
+++ b/resources/resolver.go
@@ -84,8 +84,8 @@ func GetResourceEntries(typ ResourceType) ResourceEntryDefs {
 	case RESOURCETYPE_TRANSFORMERS:
 		return ResourceEntryDefs{
 			"config.json":             RESOURCE_REQUIRED,
-			"vocab.json":              RESOURCE_OPTIONAL,
-			"merges.txt":              RESOURCE_OPTIONAL,
+			"vocab.json":              RESOURCE_REQUIRED,
+			"merges.txt":              RESOURCE_REQUIRED,
 			"special_tokens_map.json": RESOURCE_OPTIONAL,
 			"unitrim.json":            RESOURCE_OPTIONAL,
 			"wordtokens.json":         RESOURCE_OPTIONAL,


### PR DESCRIPTION
Report a bit more on inputs for debug, and make them use `log.SprintF` instead of `printf`