### PR TITLE
Fix missing model_index.json download

### DIFF
--- a/resources/resolver.go
+++ b/resources/resolver.go
@@ -110,6 +110,7 @@ func GetResourceEntries(typ ResourceType) ResourceEntryDefs {
 			"unet/diffusion_pytorch_model.bin":           RESOURCE_MODEL,
 			"vae/config.json":                            RESOURCE_REQUIRED,
 			"vae/diffusion_pytorch_model.bin":            RESOURCE_MODEL,
+			"model_index.json":                           RESOURCE_REQUIRED,
 		}
 	default:
 		return ResourceEntryDefs{}


### PR DESCRIPTION
When downloading Stable Diffusion models, the `model_index.json` is a required file in the latest version of Diffusers.