### PR TITLE
Set safety checker resource to optional for SD 2 models and fix typo

### DIFF
--- a/resources/resolver.go
+++ b/resources/resolver.go
@@ -96,10 +96,10 @@ func GetResourceEntries(typ ResourceType) ResourceEntryDefs {
 		}
 	case RESOURCETYPE_DIFFUSERS:
 		return ResourceEntryDefs{
-			"feature_extractor/preprocessor_config.json": RESOURCE_REQUIRED,
+			"feature_extractor/preprocessor_config.json": RESOURCE_OPTIONAL,
 			"safety_checker/config.json":                 RESOURCE_OPTIONAL,
-			"safety_checker/pytorch_model.json":          RESOURCE_OPTIONAL,
-			"scheduler/scheduler_config.json":            RESOURCE_OPTIONAL,
+			"safety_checker/pytorch_model.bin":           RESOURCE_OPTIONAL,
+			"scheduler/scheduler_config.json":            RESOURCE_REQUIRED,
 			"text_encoder/config.json":                   RESOURCE_REQUIRED,
 			"text_encoder/pytorch_model.bin":             RESOURCE_MODEL,
 			"tokenizer/merges.txt":                       RESOURCE_REQUIRED,


### PR DESCRIPTION
Latest Stable Diffusion models from Stability AI lack a safety checker, additionally there was a typo left into the resource path for the safety checker where the downloader tries to download `safety_checker/pytorch_model.json` instead of `safety_checker/pytorch_model.bin`.