### PR TITLE
Allow downloading of tokenizer only

### DIFF
--- a/cmd/model_downloader/model_resolver.go
+++ b/cmd/model_downloader/model_resolver.go
@@ -15,6 +15,8 @@ func main() {
 		"where to download the model to")
 	modelType := flag.String("type", "transformers",
 		"model type (transformers or diffusers)")
+	tokenizerOnly := flag.Bool("tokenizer-only", false,
+		"only download the tokenizer")
 	flag.Parse()
 	if *modelId == "" {
 		flag.Usage()
@@ -32,13 +34,20 @@ func main() {
 		flag.Usage()
 		log.Fatalf("Invalid model type: %s", *modelType)
 	}
-	
+
+	var rsrcLvl resources.ResourceFlag
+	if *tokenizerOnly {
+		rsrcLvl = resources.RESOURCE_DERIVED
+	} else {
+		rsrcLvl = resources.RESOURCE_MODEL
+	}
+
 	// get HF_API_TOKEN from env for huggingface auth
 	hfApiToken := os.Getenv("HF_API_TOKEN")
 
 	os.MkdirAll(*destPath, 0755)
 	_, rsrcErr := resources.ResolveResources(*modelId, destPath,
-		resources.RESOURCE_MODEL, rsrcType, hfApiToken)
+		rsrcLvl, rsrcType, hfApiToken)
 	if rsrcErr != nil {
 		fmt.Sprintf("Error downloading model resources: %s", rsrcErr)
 	}


### PR DESCRIPTION
Currently the model downloader downloads both the model weights and tokenizer, this PR adds functionality that allows users to download only the tokenizer in cases where model weights are not required to be downloaded.