### PR TITLE
fix: Support reorder being 'none'

### DIFF
--- a/cmd/dataset_tokenizer/dataset_tokenizer.go
+++ b/cmd/dataset_tokenizer/dataset_tokenizer.go
@@ -167,7 +167,7 @@ func ReadTexts(dirPath string, sanitize bool, sortSpec string) (TextsIterator,
 		return nil, err
 	}
 
-	if sortSpec != "" && sortSpec != "shuffle" {
+	if sortSpec != "" && sortSpec != "none" && sortSpec != "shuffle" {
 		if sortSpec == "size_ascending" {
 			SortPathInfoBySize(matches, true)
 		} else if sortSpec == "size_descending" {

--- a/resources/resolver.go
+++ b/resources/resolver.go
@@ -399,7 +399,7 @@ func ResolveResources(
 					err))
 		}
 
-		err = ExtractVocabFromTokenizer(model, dir)
+		err = ExtractVocabFromTokenizer(model, dir, &foundResources)
 		if err != nil {
 			return &foundResources, errors.New(
 				fmt.Sprintf("Could not extract vocab from tokenizer %s",
@@ -418,7 +418,7 @@ func ResolveResources(
 					err))
 		}
 
-		err = ExtractMergesFromTokenizer(model, dir)
+		err = ExtractMergesFromTokenizer(model, dir, &foundResources)
 		if err != nil {
 			return &foundResources, errors.New(
 				fmt.Sprintf("Could not extract merges from tokenizer %s",
@@ -738,7 +738,7 @@ func ExtractModelFromTokenizer(dir *string) (map[string]interface{}, error) {
 	}
 }
 
-func ExtractVocabFromTokenizer(model map[string]interface{}, dir *string) error {
+func ExtractVocabFromTokenizer(model map[string]interface{}, dir *string, resources *Resources) error {
 	vocab, ok := model["vocab"].(map[string]interface{})
 	if !ok {
 		log.Println("Error: Could not convert vocab in model to map")
@@ -771,10 +771,14 @@ func ExtractVocabFromTokenizer(model map[string]interface{}, dir *string) error 
 
 	log.Println("Vocab written to vocab.json from tokenizer.json")
 
+	if mmapErr := resources.AddEntry("vocab.json", vocabFile); mmapErr != nil {
+		return errors.New(fmt.Sprintf("error trying to mmap file: %s", mmapErr))
+	}
+
 	return nil
 }
 
-func ExtractMergesFromTokenizer(model map[string]interface{}, dir *string) error {
+func ExtractMergesFromTokenizer(model map[string]interface{}, dir *string, resources *Resources) error {
 	merges, ok := model["merges"].([]interface{})
 	if !ok {
 		log.Println("Error: Could not convert merges in model to map")
@@ -807,6 +811,10 @@ func ExtractMergesFromTokenizer(model map[string]interface{}, dir *string) error
 	}
 
 	log.Println("Merges written to merges.txt from tokenizer.json")
+
+	if mmapErr := resources.AddEntry("merges.txt", mergesFile); mmapErr != nil {
+		return errors.New(fmt.Sprintf("error trying to mmap file: %s", mmapErr))
+	}
 
 	return nil
 }


### PR DESCRIPTION
The `dataset_tokenizer` initially supports `none` as a possible value for the `-reorder` flag. However, when getting to[ `ReadTexts`](https://github.com/wbrown/gpt_bpe/blob/fd6ec51ac63c3e4a95f5efab7b4786b60a3be8ed/cmd/dataset_tokenizer/dataset_tokenizer.go#L182), having a value of `none` will cause an error.

This fix treats a value of `none` the same way it does the default blank string instead of throwing an error. 