### PR TITLE
run go get before workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Publish
 
 on:
   push:
-    branches: ['main']
+    branches: ["main"]
 
 jobs:
   publish:
@@ -16,5 +16,7 @@ jobs:
 
       - uses: imjasonh/setup-ko@v0.6
       - run: ko publish --base-import-paths ./cmd/model_downloader -t ${GITHUB_SHA::7}
+      - working-directory: ./cmd/dataset_tokenizer
+        run: go get github.com/wbrown/gpt_bpe/resources
       - working-directory: ./cmd/dataset_tokenizer
         run: ko publish --base-import-paths . -t ${GITHUB_SHA::7}

--- a/cmd/dataset_tokenizer/dataset_tokenizer.go
+++ b/cmd/dataset_tokenizer/dataset_tokenizer.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"path/filepath"
 	"math/rand"
 	"os"
 	"path/filepath"


### PR DESCRIPTION
This PR runs the "go get github.com/wbrown/gpt_bpe/resources" before building dataset_tokenizer.

Also fixes filepath once and for all because I can't count and double imported.