### PR TITLE
fix: Fix the handling of 32-bit tokens in several places

### DIFF
--- a/cmd/dataset_tokenizer/dataset_tokenizer.go
+++ b/cmd/dataset_tokenizer/dataset_tokenizer.go
@@ -758,11 +758,14 @@ func (tt TextsTokenizer) handleExclusions(
 func (tt TextsTokenizer) TokenizeTexts(
 	texts chan namedRuneReader,
 	indexPath string,
+	tokenizerPtr *gpt_bpe.GPTEncoder,
 ) (chan gpt_bpe.Tokens, error) {
-	tokenizerPtr, tokErr := tt.InitTokenizer()
-
-	if tokErr != nil {
-		return nil, tokErr
+	var tokErr error
+	if tokenizerPtr == nil {
+		tokenizerPtr, tokErr = tt.InitTokenizer()
+		if tokErr != nil {
+			return nil, tokErr
+		}
 	}
 	tokenizer := *tokenizerPtr
 	var endOfText gpt_bpe.Token
@@ -853,11 +856,14 @@ func (tt TextsTokenizer) TokenizeTexts(
 // that returns tokenized contexts that are fixed and padded out to
 // `contextSize`.
 func (tt TextsTokenizer) TokenizeTextsToContexts(
-	texts chan namedRuneReader,
+	texts chan namedRuneReader, tokenizerPtr *gpt_bpe.GPTEncoder,
 ) (chan gpt_bpe.Tokens, error) {
-	tokenizerPtr, tokErr := tt.InitTokenizer()
-	if tokErr != nil {
-		return nil, tokErr
+	var tokErr error
+	if tokenizerPtr == nil {
+		tokenizerPtr, tokErr = tt.InitTokenizer()
+		if tokErr != nil {
+			return nil, tokErr
+		}
 	}
 	tokenizer := *tokenizerPtr
 	var padToken, endOfText gpt_bpe.Token
@@ -1116,15 +1122,22 @@ func WriteContexts(
 	sampling int,
 	shuffle bool,
 	enforceUint32 bool,
+	showContexts bool,
 ) (int, error) {
 	totalTokens := 0
-	var useUint32 bool
-	// We only use uint32 if we're enforcing it and vocab size is greater than
-	// 65536.
-	if encoder != nil {
-		if enforceUint32 && len(encoder.Encoder) > 65536 {
+	useUint32 := enforceUint32
+	// Use uint32 if explicitly requested or if the vocab size is greater than 65536.
+	if !useUint32 {
+		if encoder == nil {
+			return 0, fmt.Errorf("WriteContexts called with unknown encoder; cannot determine output byte width")
+		} else if len(encoder.Encoder) > 65536 {
 			useUint32 = true
+			log.Println("warning: tokenizer vocab too large for 16-bit, outputting as 32-bit")
 		}
+	}
+	if showContexts && encoder == nil {
+		showContexts = false
+		log.Println("warning: no encoder info, cannot show contexts")
 	}
 
 	// create file AND filepath if not exists
@@ -1158,6 +1171,11 @@ func WriteContexts(
 				doKeepSampling := sampling == 100 || (samplingIdx%lcd < skipEveryX)
 				if doKeepSampling {
 					sampledContexts <- context
+					if showContexts {
+						fmt.Println(len(context))
+						fmt.Println("======================================")
+						fmt.Println(encoder.Decode(&context))
+					}
 				}
 				samplingIdx += 1
 			}
@@ -1187,7 +1205,10 @@ func WriteContexts(
 		if !ok {
 			break
 		}
-		binContext := context.ToBin(useUint32)
+		binContext, err := context.ToBin(useUint32)
+		if err != nil {
+			return totalTokens, err
+		}
 		// We keep track of the final file position
 		if endpos == 0 {
 			// On the first context, we discern the context size and make the
@@ -1421,7 +1442,7 @@ func main() {
 	)
 	enforceUint32 := flag.Bool(
 		"uint32_enforce", false,
-		"enforce uint32 tokenization if needed (vocab size > 65535)",
+		"output tokens as uint32 instead of uint16 (required for vocabs with over 2^16 tokens)",
 	)
 
 	flag.Parse()
@@ -1513,7 +1534,9 @@ func main() {
 			)
 		}
 	}
-	if _, tokErr := textsTokenizer.InitTokenizer(); tokErr != nil {
+
+	encoder, tokErr := textsTokenizer.InitTokenizer()
+	if tokErr != nil {
 		log.Fatal(tokErr)
 	}
 
@@ -1591,13 +1614,19 @@ func main() {
 				contexts, tokErr = textsTokenizer.TokenizeTexts(
 					textReaders,
 					indexFilePath,
+					encoder,
 				)
 				if tokErr != nil {
 					log.Fatal(tokErr)
 				}
 				total, writeErr := WriteContexts(
-					outputFilePath, contexts,
-					nil, sampling, false, *enforceUint32,
+					outputFilePath,
+					contexts,
+					encoder,
+					sampling,
+					false,
+					*enforceUint32,
+					*showContexts,
 				)
 				if writeErr != nil {
 					log.Fatal(writeErr)
@@ -1611,20 +1640,20 @@ func main() {
 		var contexts chan gpt_bpe.Tokens
 		var tokErr error
 		contexts, tokErr = textsTokenizer.TokenizeTextsToContexts(
-			textReaders,
+			textReaders, encoder,
 		)
 		if tokErr != nil {
 			log.Fatal(tokErr)
 		}
-		var enc *gpt_bpe.GPTEncoder
-		if *showContexts {
-			enc, _ = textsTokenizer.InitTokenizer()
-		}
 		var writeErr error
 		numTokens, writeErr = WriteContexts(
-			*outputFile, contexts, enc,
+			*outputFile,
+			contexts,
+			encoder,
 			sampling,
-			*reorderPaths == "shuffle", *enforceUint32,
+			*reorderPaths == "shuffle",
+			*enforceUint32,
+			*showContexts,
 		)
 		if writeErr != nil {
 			log.Fatal(writeErr)

--- a/cmd/dataset_tokenizer/dataset_tokenizer.go
+++ b/cmd/dataset_tokenizer/dataset_tokenizer.go
@@ -631,11 +631,17 @@ func getAndCheckToken(
 	s = strings.ReplaceAll(s, "\\n", "\n")
 	token := t.Get(s)
 	if token == nil {
-		tokens := t.Encode(&s)
-		if len(*tokens) != 1 {
-			return 0, fmt.Errorf("'%s' is not a valid token for %s", s, id)
+		tokens := *t.Encode(&s)
+		// Also allow a single "real" token surrounded by an EosToken and/or a BosToken
+		if len(tokens) == 1 ||
+			len(tokens) == 2 && tokens[1] == t.EosToken && tokens[0] != t.BosToken {
+			return tokens[0], nil
+		} else if len(tokens) == 3 &&
+			tokens[0] == t.BosToken && tokens[2] == t.EosToken ||
+			len(tokens) == 2 && tokens[0] == t.BosToken && tokens[1] != t.EosToken {
+			return tokens[1], nil
 		} else {
-			return (*tokens)[0], nil
+			return 0, fmt.Errorf("'%s' is not a valid token for %s", s, id)
 		}
 	} else {
 		return *token, nil

--- a/cmd/dataset_tokenizer/dataset_tokenizer.go
+++ b/cmd/dataset_tokenizer/dataset_tokenizer.go
@@ -900,7 +900,7 @@ func (tt TextsTokenizer) TokenizeTextsToContexts(
 
 	var boundary gpt_bpe.Token
 	if tt.Boundary == "" {
-		boundary = 65535
+		boundary = 0xFFFFFFFF
 	} else {
 		var boundaryErr error
 		boundary, boundaryErr = getAndCheckToken(
@@ -1058,7 +1058,7 @@ func (tt TextsTokenizer) TokenizeTextsToContexts(
 					// We were given a hard index to use as the chunk boundary,
 					// and it may not be a complete unicode character, so we
 					// need to align it to a valid unicode character.
-					if boundary == 65535 && doUnitrim {
+					if boundary == 0xFFFFFFFF && doUnitrim {
 						// Ensure that our next chunk is aligned to valid
 						// unicode.
 						_, offset := tokenizer.AlignAndSizeTokens(

--- a/cmd/dataset_tokenizer/dataset_tokenizer_test.go
+++ b/cmd/dataset_tokenizer/dataset_tokenizer_test.go
@@ -228,9 +228,7 @@ func TestEncodeText1(t *testing.T) {
 	textsTokenizer.BoundaryBegin = false
 	var enc *gpt_bpe.GPTEncoder
 
-	reorderPaths := ""
 	sampling := 100
-	enforceUint32 := true // Only if needed
 	outputFile := "base.chunk"
 
 	enc, tokErr := textsTokenizer.InitTokenizer()
@@ -252,14 +250,19 @@ func TestEncodeText1(t *testing.T) {
 	}()
 
 	begin := time.Now()
-	contexts, tokErr := textsTokenizer.TokenizeTexts(reader, "./test")
+	contexts, tokErr := textsTokenizer.TokenizeTexts(reader, "./test", enc)
 	if tokErr != nil {
 		log.Fatal("Error tokenizing texts: ", tokErr)
 	}
 
 	total, writeErr := WriteContexts(
-		outputFile, contexts, enc, sampling, reorderPaths == "shuffle",
-		enforceUint32,
+		outputFile,
+		contexts,
+		enc,
+		sampling,
+		false,
+		false,
+		false,
 	)
 	if writeErr != nil {
 		log.Fatal("Error writing contexts: ", writeErr)
@@ -310,7 +313,8 @@ func TestSampling50(t *testing.T) {
 	sampling := 100
 	outputFile := "base.chunk"
 
-	if _, tokErr := textsTokenizer.InitTokenizer(); tokErr != nil {
+	enc, tokErr := textsTokenizer.InitTokenizer()
+	if tokErr != nil {
 		log.Fatal(tokErr)
 	}
 
@@ -323,18 +327,22 @@ func TestSampling50(t *testing.T) {
 	} else {
 		begin := time.Now()
 		contexts, tokErr := textsTokenizer.TokenizeTexts(
-			texts, "./test",
+			texts, "./test", enc,
 		)
 		if tokErr != nil {
 			log.Fatal(tokErr)
 		}
 
-		var enc *gpt_bpe.GPTEncoder
 		// *showContexts = true
 
 		total, writeErr := WriteContexts(
-			outputFile, contexts, enc, sampling,
-			reorderPaths == "shuffle", false,
+			outputFile,
+			contexts,
+			enc,
+			sampling,
+			false,
+			false,
+			false,
 		)
 		all1 += total
 		if writeErr != nil {
@@ -361,7 +369,8 @@ func TestSampling50(t *testing.T) {
 	sampling = 50
 	outputFile = "samp50.chunk"
 
-	if _, tokErr := textsTokenizer.InitTokenizer(); tokErr != nil {
+	enc, tokErr = textsTokenizer.InitTokenizer()
+	if tokErr != nil {
 		log.Fatal(tokErr)
 	}
 
@@ -374,16 +383,20 @@ func TestSampling50(t *testing.T) {
 	} else {
 		begin := time.Now()
 		contexts, tokErr := textsTokenizer.TokenizeTexts(
-			texts2, "./test",
+			texts2, "./test", enc,
 		)
 		if tokErr != nil {
 			log.Fatal(tokErr)
 		}
-		var enc *gpt_bpe.GPTEncoder
 		// *showContexts = true
 
 		total2, writeErr := WriteContexts(
-			outputFile, contexts, enc, sampling, reorderPaths == "shuffle",
+			outputFile,
+			contexts,
+			enc,
+			sampling,
+			reorderPaths == "shuffle",
+			false,
 			false,
 		)
 		all2 += total2
@@ -430,7 +443,8 @@ func TestShuffle(t *testing.T) {
 	sampling := 100
 	outputFile := "noshuffle.chunk"
 
-	if _, tokErr := textsTokenizer.InitTokenizer(); tokErr != nil {
+	enc, tokErr := textsTokenizer.InitTokenizer()
+	if tokErr != nil {
 		log.Fatal(tokErr)
 	}
 
@@ -442,16 +456,20 @@ func TestShuffle(t *testing.T) {
 	} else {
 		begin := time.Now()
 		contexts, tokErr := textsTokenizer.TokenizeTexts(
-			texts, "./test",
+			texts, "./test", enc,
 		)
 		if tokErr != nil {
 			log.Fatal(tokErr)
 		}
-		var enc *gpt_bpe.GPTEncoder
 		// *showContexts = true
 
 		total, writeErr := WriteContexts(
-			outputFile, contexts, enc, sampling, reorderPaths == "shuffle",
+			outputFile,
+			contexts,
+			enc,
+			sampling,
+			false,
+			false,
 			false,
 		)
 		all1 += total
@@ -479,7 +497,8 @@ func TestShuffle(t *testing.T) {
 	sampling = 100
 	outputFile = "shuffle.chunk"
 
-	if _, tokErr := textsTokenizer.InitTokenizer(); tokErr != nil {
+	enc2, tokErr := textsTokenizer.InitTokenizer()
+	if tokErr != nil {
 		log.Fatal(tokErr)
 	}
 
@@ -491,16 +510,20 @@ func TestShuffle(t *testing.T) {
 	} else {
 		begin := time.Now()
 		contexts2, tokErr := textsTokenizer.TokenizeTexts(
-			texts2, "./test",
+			texts2, "./test", enc2,
 		)
 		if tokErr != nil {
 			log.Fatal(tokErr)
 		}
-		var enc2 *gpt_bpe.GPTEncoder
 		// *showContexts = true
 
 		total2, writeErr := WriteContexts(
-			outputFile, contexts2, enc2, sampling, reorderPaths == "shuffle",
+			outputFile,
+			contexts2,
+			enc2,
+			sampling,
+			true,
+			false,
 			false,
 		)
 		all2 += total2

--- a/cmd/tokens_transformer/tokens_transformer.go
+++ b/cmd/tokens_transformer/tokens_transformer.go
@@ -20,6 +20,10 @@ func main() {
 		"show contexts as they are retokenized")
 	unitrimBool := flag.Bool("no_unitrim", false,
 		"do not trim to valid unicode retokenized contexts")
+	in32 := flag.Bool("in32", false,
+		"force input tokens to be read as 32-bit")
+	out32 := flag.Bool("out32", false,
+		"force output tokens to be written as 32-bit")
 	inputFile := flag.String("input", "",
 		"input file to retokenize")
 	outputFile := flag.String("output", "retokenized.tokens",
@@ -53,14 +57,30 @@ func main() {
 	if _, err := os.Stat(*inputFile); os.IsNotExist(err) {
 		log.Fatal("Input file does not exist")
 	}
-	inputTokenizer, inputErr := gpt_bpe.NewEncoder(*inputTokenizerId)
+
+	// Check if it's an internal reference. If not, it's a file path.
+	inputTokenizer, inputErr := gpt_bpe.NewEncoder(
+		*inputTokenizerId + "-tokenizer")
 	if inputErr != nil {
-		log.Fatal(inputErr)
+		// Fall back to path-like.
+		inputTokenizer, inputErr = gpt_bpe.NewEncoder(*inputTokenizerId)
+		if inputErr != nil {
+			log.Fatal(inputErr)
+		}
 	}
-	outputTokenizer, outputErr := gpt_bpe.NewEncoder(*outputTokenizerId)
+	input32Bit := *in32 || len(inputTokenizer.Encoder) > 65536
+
+	outputTokenizer, outputErr := gpt_bpe.NewEncoder(
+		*outputTokenizerId + "-tokenizer")
 	if outputErr != nil {
-		log.Fatal(outputErr)
+		// Fall back to path-like.
+		outputTokenizer, outputErr = gpt_bpe.NewEncoder(*outputTokenizerId)
+		if outputErr != nil {
+			log.Fatal(outputErr)
+		}
 	}
+	output32Bit := *out32 || len(outputTokenizer.Encoder) > 65536
+
 	// open input file
 	inputFileHandle, inputOpenErr := os.Open(*inputFile)
 	if inputOpenErr != nil {
@@ -94,8 +114,13 @@ func main() {
 			break
 		}
 
+		if input32Bit {
+			log.Println("Reading as 32-bit")
+		} else {
+			log.Println("Reading as 16-bit")
+		}
 		context := contextBuffer[:bytesRead]
-		decoded := inputTokenizer.DecodeBuffer(&context)
+		decoded := inputTokenizer.DecodeBuffer(&context, input32Bit)
 		encoded := outputTokenizer.Encode(&decoded)
 		// trim encoded tokens to context size
 		if len(*encoded) > *contextSize {
@@ -115,7 +140,12 @@ func main() {
 			encoded = &padded
 		}
 		// write encoded context to output file
-		bytesToWrite, _ := encoded.ToBin(false)
+		if output32Bit {
+			log.Println("Writing as 32-bit")
+		} else {
+			log.Println("Writing as 16-bit")
+		}
+		bytesToWrite, _ := encoded.ToBin(output32Bit)
 		bytesWritten, writeErr := outputFileHandle.Write(*bytesToWrite)
 
 		if writeErr != nil {

--- a/cmd/tokens_transformer/tokens_transformer.go
+++ b/cmd/tokens_transformer/tokens_transformer.go
@@ -115,7 +115,7 @@ func main() {
 			encoded = &padded
 		}
 		// write encoded context to output file
-		bytesToWrite := encoded.ToBin(false)
+		bytesToWrite, _ := encoded.ToBin(false)
 		bytesWritten, writeErr := outputFileHandle.Write(*bytesToWrite)
 
 		if writeErr != nil {

--- a/gpt_bpe.go
+++ b/gpt_bpe.go
@@ -1216,19 +1216,21 @@ func (encoder *GPTEncoder) EncodeReader(reader io.RuneReader) *Tokens {
 
 // EncodeBuffer takes a byte array and encodes it into Tokens in another
 // byte array.
-func (encoder *GPTEncoder) EncodeBuffer(buffer *[]byte) *[]byte {
+func (encoder *GPTEncoder) EncodeBuffer(buffer *[]byte) (*[]byte, uint64) {
 	runeReader := bytes.NewReader(*buffer)
 	nextTokens := encoder.StreamingEncode(runeReader)
 	buf := bytes.NewBuffer(make([]byte, 0, 4096))
+	var count uint64 = 0
 	for {
 		tokens := nextTokens(2048)
 		if tokens == nil {
 			break
 		}
 		_ = binary.Write(buf, binary.LittleEndian, tokens)
+		count += uint64(len(*tokens))
 	}
 	bufBytes := buf.Bytes()
-	return &bufBytes
+	return &bufBytes, count
 }
 
 // Encode encodes a string into a sequence of tokens.

--- a/gpt_bpe.go
+++ b/gpt_bpe.go
@@ -1335,9 +1335,14 @@ func (encoder *GPTEncoder) Decode(encoded *Tokens) (text string) {
 
 // DecodeBuffer
 // Decode Tokens from a byte array into a string.
-func (encoder *GPTEncoder) DecodeBuffer(encoded *[]byte) (text string) {
+func (encoder *GPTEncoder) DecodeBuffer(encoded *[]byte, useUint32 bool) (text string) {
 	// First convert our bytearray into uint32 `Token` array.
-	tokens := types.TokensFromBin(encoded)
+	var tokens *Tokens
+	if useUint32 {
+		tokens = types.TokensFromBin32(encoded)
+	} else {
+		tokens = types.TokensFromBin(encoded)
+	}
 	// Decode our tokens into a string.
 	return encoder.Decode(tokens)
 }

--- a/gpt_bpe_test.go
+++ b/gpt_bpe_test.go
@@ -514,7 +514,7 @@ func BenchmarkGPTEncoder_Encode(b *testing.B) {
 func BenchmarkGPTEncoder_EncodeBuffer(b *testing.B) {
 	corpusBytes := []byte(corpus)
 	start := time.Now()
-	tokenCt := len(*gpt2Encoder.EncodeBuffer(&corpusBytes)) / 2
+	_, tokenCt := gpt2Encoder.EncodeBuffer(&corpusBytes)
 	duration := time.Since(start)
 	b.Logf(
 		"%v bytes into %v tokens over %v",

--- a/lib/library.go
+++ b/lib/library.go
@@ -6,11 +6,13 @@ package main
 import "C"
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"time"
 	"unsafe"
 
 	"github.com/wbrown/gpt_bpe"
+	"github.com/wbrown/gpt_bpe/types"
 )
 
 var tokenizers map[string]*gpt_bpe.GPTEncoder
@@ -63,8 +65,8 @@ func tokenizeBuffer(vocabIdStr *C.char, buf *C.char, sz C.size_t) C.Tokens {
 }
 
 // tokenize accepts a vocabulary and text as a C string, and returns a C.Tokens
-// that contains a malloc'ed array of uint32_t tokens along with the number of
-// tokens.
+// that contains a malloc'ed array of little-endian uint32_t tokens along with
+// the number of tokens.
 //
 //export tokenize
 func tokenize(vocabIdStr *C.char, str *C.char) C.Tokens {
@@ -78,7 +80,12 @@ func tokenize(vocabIdStr *C.char, str *C.char) C.Tokens {
 	fmt.Printf("input: %s\n", s)
 	encoded := *encoder.Encode(&s)
 	fmt.Printf("Tokens: %v\n", encoded)
-	tokensArr := C.CBytes(*encoded.ToBin(false))
+	encodedBinary, err := encoded.ToBin(true)
+	if err == nil || encodedBinary == nil {
+		_, _ = fmt.Fprintf(os.Stderr, "tokenize: failed to write tokens as uint32_t")
+		return C.Tokens{tokens: nil, len: 0}
+	}
+	tokensArr := C.CBytes(*encodedBinary)
 	tokens := C.Tokens{
 		tokens: (*C.uint32_t)(tokensArr),
 		len:    C.size_t(len(encoded)),
@@ -101,8 +108,8 @@ func decode(vocabIdStr *C.char, tokens C.Tokens) *C.char {
 		initTokenizer(vocabIdStr)
 		encoder = tokenizers[tokenizerId]
 	}
-	tokensArr := C.GoBytes(unsafe.Pointer(tokens.tokens), C.int(tokens.len)*2)
-	goTokens := gpt_bpe.TokensFromBin(&tokensArr)
+	tokensArr := C.GoBytes(unsafe.Pointer(tokens.tokens), C.int(tokens.len)*4)
+	goTokens := types.TokensFromBin32(&tokensArr)
 	fmt.Printf("goTokens: %v\n", goTokens)
 	decoded := encoder.Decode(goTokens)
 	fmt.Printf("Decoded: %s\n", decoded)

--- a/lib/library.go
+++ b/lib/library.go
@@ -55,11 +55,11 @@ func tokenizeBuffer(vocabIdStr *C.char, buf *C.char, sz C.size_t) C.Tokens {
 		encoder = tokenizers[tokenizerId]
 	}
 	goBuf := createBuffer(unsafe.Pointer(buf), int(sz))
-	encoded := *encoder.EncodeBuffer(goBuf)
-	tokensArr := C.CBytes(encoded)
+	encoded, tokenCount := encoder.EncodeBuffer(goBuf)
+	tokensArr := C.CBytes(*encoded)
 	tokens := C.Tokens{
 		tokens: (*C.uint32_t)(tokensArr),
-		len:    (C.size_t)(len(encoded) / 2),
+		len:    (C.size_t)(tokenCount),
 	}
 	return tokens
 }

--- a/resources/resolver.go
+++ b/resources/resolver.go
@@ -553,7 +553,7 @@ func ResolveResources(
 					)
 				}
 				log.Printf(
-					"Added %s to resources via sentancepiece conversion\n",
+					"Added %s to resources via sentencepiece conversion\n",
 					f.Name(),
 				)
 			}

--- a/types/shared.go
+++ b/types/shared.go
@@ -3,7 +3,3 @@ package types
 type Token uint32
 type Tokens []Token
 type TokenMap map[string]Token
-
-const (
-	TokenSize = 2
-)


### PR DESCRIPTION
# Fixing 32-bit Token Handling

This PR fixes several issues left regarding 32-bit token handling after #49 & #50.

## Core library changes

`types.ToBin` can now report errors. In particular, it will raise an error if it tries to write a token as 16-bit that would overflow a `uint16`, which was occurring as a silent error until this PR. This should allow such mismatches to be caught more easily in the future.

`gpt_bpe.EncodeBuffer` now returns the number of tokens it encoded. This had previously been guessed by dividing its output length by 2, which isn't applicable since the change to allow 32-bit tokens. Since the call sites for this were getting invalid token counts, they were broken, so this change fixes them.

`gpt_bpe.DecodeBuffer` had no way to decode 32-bit tokens from a byte array, only 16-bit tokens. That functionality has now been added, and the `cmd` utilities using it have subsequently also been changed to make use of that, and now support 32-bit tokens as well.

## `dataset_tokenizer`

Bizarrely, until this PR, the `-uint32_enforce` flag in `dataset_tokenizer` produced 16-bit files unless `-show_contexts` was also specified, plus a few other conditions. This was fixed so that it actually produces output files with 32-bit tokens.

This change also switches around the semantics of `-uint32_enforce`. Previously, the logic for choosing 16-bit or 32-bit output was:
> Always use 16-bit, unless `-uint32_enforce` was specified,
> AND the encoder is known in the `WriteContexts` call,
> AND the encoder has a vocab larger than 65536 tokens

Now, the logic is:
> Use 16-bit unless `-uint32_enforce` was specified, then use 32-bit
> OR if the encoder has a vocab larger than 65536, use 32-bit anyway
> BUT if `-uint32_enforce` was unspecified and the encoder is unknown, raise an error

It additionally emits a warning when promoting to 32-bit output without the `-uint32_enforce` flag, because it has a major impact on how the file will be read, and the token width is not tagged in the file itself.

### `-show_contexts`

This also fixes the `-show_contexts` flag, which was broken in that, well, it didn't show any contexts, as its implementation was mistakenly removed when `-uint32_enforce` was added [in commit dcd214b](https://github.com/wbrown/gpt_bpe/commit/dcd214bb01b059053f4dea55539e2df1fff150f1#diff-95b21cb9ebf798caa818e552d00ac0eda147541a4ff391bbe43995a6052e6dd4L1056-L1060).

### Placeholder boundary tokens

"`65535`" was still being used as a hardcoded placeholder token for boundary tokens in `dataset_tokenizer`. This change switches it to use `0xFFFFFFFF` instead, since `65535` is a valid token in newer 32-bit tokenizer vocabularies.

### `getAndCheckToken` / Llama3 newlines

`getAndCheckToken` previously would not recognize a string as a valid token even if it encoded to a single "real" token if BOS/EOS markers were tacked onto the encoded representation. This PR includes a change to check for that case and extract the real token from such a group if found.

This is necessary to be able to set `\n` as a special token while using the Llama3 tokenizer vocabulary, which treats `\n` as a single token, but uses an alternative representation for it (`Ċ`) in its vocab definitions.

## `tokens_transformer`

`tokens_transformer` supported using neither 32-bit tokens in its input file nor its output file. This was fixed, and its token width autodetection works the same as in `dataset_tokenizer`, with `-in32` and `-out32` flags to force either file to be read/written as 32-bit even if they wouldn't normally be.

`tokens_transformer` still doesn't work quite right when converting from Llama3, as the BOS and EOS tokens end up being retokenized as real text. This is likely the case for special token conversions between any tokenizer at the moment. This is not addressed in this PR as it is out-of-scope.

Finally, the `-input_tokenizer` and `-output_tokenizer` options to `tokens_transformer` now correctly interpret embedded names like `llama3` or `pile` as documented, instead of needing them to be written out with their internal `-tokenizer` suffix.

## `detokenizer`

`detokenizer` didn't support detokenizing 32-bit-encoded input files. Now it does so with the same behaviour as `tokens_transformer`, using the same flag (`-in32`).

Additionally, the buffering code was fixed to not detokenize unset bytes out of the read buffer after an incomplete read, and to reuse the read buffer instead of constantly reallocating it.

## `lib/library.go`

`lib/library.go` was quite broken (and not even able to be compiled) after the original changes to the library for 32-bit tokens. I fixed what I could find out of it to support 32-bit tokens, though it hasn't undergone thorough testing to verify if it's fully back to business yet.

Additionally, the documentation for the `tokenize` function has been changed to point out that it always outputs little-endian tokens (regardless of the native machine endianness). I'm not sure how correct it is to behave this way, as it purports to give `uint32_t` C values rather than pure bytes, which one might assume are usable as valid individual token IDs, but that is what its behaviour has been historically. Nonetheless, `binary.NativeEndian` doesn't seem to be supported in some Go versions without extra packages, and documenting it is enough to allow that difference to be accounted for if needed, so it was simply added to its docstring comment for reference.