### PR TITLE
Use compressed `wiki.train.raw.xz`.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/gopherjs/gopherjs v1.19.0-beta1
 	github.com/jdkato/prose/v2 v2.0.0
 	github.com/pkg/errors v0.9.1
+	github.com/ulikunitz/xz v0.5.12
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/ulikunitz/xz v0.5.12 h1:37Nm15o69RwBkXM0J6A5OlE67RZTfzUxTj8fB3dfcsc=
+github.com/ulikunitz/xz v0.5.12/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vikesh-raj/go-sentencepiece-encoder v1.1.1 h1:q5Rm4ihhwmAiDycaL8rNiE/ly4on+nHQajElYLPN7TM=
 github.com/vikesh-raj/go-sentencepiece-encoder v1.1.1/go.mod h1:GlANpY4lgPZT+cpb0pkEJrTMbICKc74KleEZwEiGqmU=

--- a/gpt_bpe_test.go
+++ b/gpt_bpe_test.go
@@ -360,7 +360,7 @@ func BenchmarkGPTEncoder_WordSplitterChan(b *testing.B) {
 	b.ReportMetric(float64(wordCount)/elapsed.Seconds(), "words/sec")
 	b.ReportMetric(float64(wordCount), "words")
 	b.ReportMetric(
-		float64(numBytes)/elapsed.Seconds(), "compressed bytes/sec",
+		float64(numBytes)/elapsed.Seconds(), "compbytes/sec",
 	)
 	b.ReportMetric(float64(numBytes), "bytes")
 }
@@ -396,7 +396,7 @@ func BenchmarkGPTEncoder_WordSplitter(b *testing.B) {
 	b.ReportMetric(float64(wordCount)/elapsed.Seconds(), "words/sec")
 	b.ReportMetric(float64(wordCount), "words")
 	b.ReportMetric(
-		float64(numBytes)/elapsed.Seconds(), "compressed bytes/sec",
+		float64(numBytes)/elapsed.Seconds(), "compbytes/sec",
 	)
 	b.ReportMetric(float64(numBytes), "bytes")
 }
@@ -436,7 +436,7 @@ func BenchmarkGPTEncoder_WordSplitterTokens(b *testing.B) {
 	b.ReportMetric(float64(wordCount)/elapsed.Seconds(), "words/sec")
 	b.ReportMetric(float64(wordCount), "words")
 	b.ReportMetric(
-		float64(numBytes)/elapsed.Seconds(), "compressed bytes/sec",
+		float64(numBytes)/elapsed.Seconds(), "compbytes/sec",
 	)
 	b.ReportMetric(float64(numBytes), "bytes")
 	b.ReportMetric(float64(tokensCount)/elapsed.Seconds(), "tokens/sec")

--- a/gpt_bpe_test.go
+++ b/gpt_bpe_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/wbrown/gpt_bpe/types"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/ulikunitz/xz"
 	"github.com/wbrown/gpt_bpe/resources"
 )
 
@@ -42,7 +43,7 @@ var llama3Encoded *Tokens
 var mistralEncoded *Tokens
 var unicodeTrimTests []*Tokens
 
-const largeCorpusPath = "resources/wiki.train.raw"
+const largeCorpusPath = "resources/wiki.train.raw.xz"
 
 func handleRead(path string) []byte {
 	if textBytes, err := os.ReadFile(path); err != nil {
@@ -316,13 +317,25 @@ func TestGPTEncoder_Split(t *testing.T) {
 	}
 }
 
+func OpenXZStream(path string) (*xz.Reader, *os.File, error) {
+	corpusHandle, err := os.Open(path)
+	if err != nil {
+		return nil, nil, err
+	}
+	decompressorHandle, err := xz.NewReader(corpusHandle)
+	if err != nil {
+		return nil, nil, err
+	}
+	return decompressorHandle, corpusHandle, nil
+}
+
 func BenchmarkGPTEncoder_WordSplitterChan(b *testing.B) {
 	b.StopTimer()
-	corpusHandle, err := os.Open(largeCorpusPath)
+	corpusHandle, fileHandle, err := OpenXZStream(largeCorpusPath)
 	if err != nil {
 		b.Error(err)
 	}
-	defer corpusHandle.Close()
+	defer fileHandle.Close()
 	gpt2Encoder.SplitterThreads = 8
 	nextWord := gpt2Encoder.WordSplitter(
 		bufio.NewReaderSize(
@@ -343,17 +356,22 @@ func BenchmarkGPTEncoder_WordSplitterChan(b *testing.B) {
 	}
 	b.StopTimer()
 	elapsed := time.Since(start)
-	numBytes, _ := corpusHandle.Seek(0, io.SeekCurrent)
+	numBytes, _ := fileHandle.Seek(0, io.SeekCurrent)
 	b.ReportMetric(float64(wordCount)/elapsed.Seconds(), "words/sec")
 	b.ReportMetric(float64(wordCount), "words")
-	b.ReportMetric(float64(numBytes)/elapsed.Seconds(), "bytes/sec")
+	b.ReportMetric(
+		float64(numBytes)/elapsed.Seconds(), "compressed bytes/sec",
+	)
 	b.ReportMetric(float64(numBytes), "bytes")
 }
 
 func BenchmarkGPTEncoder_WordSplitter(b *testing.B) {
 	b.StopTimer()
-	corpusHandle, err := os.Open(largeCorpusPath)
-	//corpusText, err := ioutil.ReadFile(largeCorpusPath)
+	corpusHandle, fileHandle, err := OpenXZStream(largeCorpusPath)
+	if err != nil {
+		b.Error(err)
+	}
+	defer fileHandle.Close()
 	gpt2Encoder.SplitterThreads = 8
 	//defer corpusHandle.Close()
 	if err != nil {
@@ -374,17 +392,22 @@ func BenchmarkGPTEncoder_WordSplitter(b *testing.B) {
 	b.StopTimer()
 	elapsed := time.Since(start)
 	//numBytes := int64(len(corpusText))
-	numBytes, _ := corpusHandle.Seek(0, io.SeekCurrent)
+	numBytes, _ := fileHandle.Seek(0, io.SeekCurrent)
 	b.ReportMetric(float64(wordCount)/elapsed.Seconds(), "words/sec")
 	b.ReportMetric(float64(wordCount), "words")
-	b.ReportMetric(float64(numBytes)/elapsed.Seconds(), "bytes/sec")
+	b.ReportMetric(
+		float64(numBytes)/elapsed.Seconds(), "compressed bytes/sec",
+	)
 	b.ReportMetric(float64(numBytes), "bytes")
 }
 
 func BenchmarkGPTEncoder_WordSplitterTokens(b *testing.B) {
 	b.StopTimer()
-	corpusHandle, err := os.Open(largeCorpusPath)
-	//corpusText, err := ioutil.ReadFile(largeCorpusPath)
+	corpusHandle, fileHandle, err := OpenXZStream(largeCorpusPath)
+	if err != nil {
+		b.Error(err)
+	}
+	defer fileHandle.Close()
 	nerdstashV2Encoder.SplitterThreads = 1
 	//defer corpusHandle.Close()
 	if err != nil {
@@ -409,10 +432,12 @@ func BenchmarkGPTEncoder_WordSplitterTokens(b *testing.B) {
 	b.StopTimer()
 	elapsed := time.Since(start)
 	//numBytes := int64(len(corpusText))
-	numBytes, _ := corpusHandle.Seek(0, io.SeekCurrent)
+	numBytes, _ := fileHandle.Seek(0, io.SeekCurrent)
 	b.ReportMetric(float64(wordCount)/elapsed.Seconds(), "words/sec")
 	b.ReportMetric(float64(wordCount), "words")
-	b.ReportMetric(float64(numBytes)/elapsed.Seconds(), "bytes/sec")
+	b.ReportMetric(
+		float64(numBytes)/elapsed.Seconds(), "compressed bytes/sec",
+	)
 	b.ReportMetric(float64(numBytes), "bytes")
 	b.ReportMetric(float64(tokensCount)/elapsed.Seconds(), "tokens/sec")
 	b.ReportMetric(float64(tokensCount), "tokens")


### PR DESCRIPTION
We've expunged the mega-large wiki training text corpus, and replaced it with a xz compressed version.

Functionality has been restored, but we may need to examine whether we're bottlenecked on the xz decompression.