### PR TITLE
Fix edge cases regarding index file writing, revert to context level index.

### DIFF
--- a/cmd/dataset_tokenizer/dataset_tokenizer.go
+++ b/cmd/dataset_tokenizer/dataset_tokenizer.go
@@ -872,13 +872,13 @@ func (tt TextsTokenizer) TokenizeTexts(
 	texts chan namedRuneReader,
 	indexPath string,
 	tokenizerPtr *gpt_bpe.GPTEncoder,
-) (chan indexContext, *TokenizerStatus, error) {
+) (chan indexContext, *TokenizerStatus, []string, error) {
 	tokenizerStatus := TokenizerStatus{}
 	var tokErr error
 	if tokenizerPtr == nil {
 		tokenizerPtr, tokErr = tt.InitTokenizer()
 		if tokErr != nil {
-			return nil, nil, tokErr
+			return nil, nil, nil, tokErr
 		}
 	} else {
 		tokenizerPtr = tokenizerPtr.Clone()
@@ -894,7 +894,7 @@ func (tt TextsTokenizer) TokenizeTexts(
 			&tokenizer,
 			tt.EndOfText, "EndOfText",
 		); eotErr != nil {
-			return nil, nil, eotErr
+			return nil, nil, nil, eotErr
 		}
 	}
 
@@ -904,14 +904,9 @@ func (tt TextsTokenizer) TokenizeTexts(
 	tokenizerStatus.Tokenized = &tokenizedTexts
 	tokenizerStatus.Texts = &texts
 
-	// Our index handle.
-	indexFile, iErr := os.Create(indexPath)
-	if iErr != nil {
-		return nil, nil, iErr
-	}
-
 	currOffset := 0
 	idxFormat := "{\"path\": \"%s\", \"offset\": %d, \"tokens\": %d}\n"
+	indexLines := []string{}
 	nextTokenized := func() {
 		for {
 			waitBegin := time.Now()
@@ -949,25 +944,23 @@ func (tt TextsTokenizer) TokenizeTexts(
 					}
 					tokenizerStatus.SendWait += time.Since(sendBegin)
 				}
-				indexFile.WriteString(
-					fmt.Sprintf(
-						idxFormat,
-						runeReader.path,
-						currOffset,
-						numTokens,
-					),
+				indexLine := fmt.Sprintf(
+					idxFormat,
+					runeReader.path,
+					currOffset,
+					numTokens,
 				)
+				indexLines = append(indexLines, indexLine)
 				currOffset += numTokens
 				numTokens = 0
 			} else {
 				close(tokenizedTexts)
-				indexFile.Close()
 				break
 			}
 		}
 	}
 	go nextTokenized()
-	return tokenizedTexts, &tokenizerStatus, nil
+	return tokenizedTexts, &tokenizerStatus, indexLines, nil
 }
 
 // TokenizeTextsToContexts
@@ -1263,6 +1256,28 @@ func (tt TextsTokenizer) TokenizeTextsToContexts(
 					}
 
 					boundaryIdxes = boundaryIdxes[:0]
+
+					// Trim any broken unicode characters from the end of the
+					// chunk, replacing them with a pad token. Normally, this
+					// would only occur on the last rune in the chunk, due to
+					// the way we align the chunk to a valid rune.
+					if doUnitrim {
+						trimmed := *tokenizerPtr.TrimTokens(&chunk)
+						if len(trimmed) != len(chunk) {
+							padSize := contextSize - len(trimmed)
+							if padSize > 0 {
+								for padIdx := 0; padIdx < padSize; padIdx += 1 {
+									trimmed = append(trimmed, padToken)
+								}
+								// Since we are substituting tokens, we probably
+								// need to subtract the number of tokens we added,
+								// while also accounting for the padding tokens.
+								status.PadTokens += padSize
+								status.NumTokens -= padSize
+							}
+						}
+					}
+
 					// Reset the `begin` offsets, move idx, to set up the
 					// state for the next invocation of this function.
 					tokenizedBuffer[0].context = tokenizedBuffer[0].context[idx:]
@@ -1423,6 +1438,7 @@ func WriteContexts(
 	indexPath string,
 	contexts chan indexContext,
 	encoder *gpt_bpe.GPTEncoder,
+	indexLines []string,
 	shuffle bool,
 	enforceUint32 bool,
 	showContexts bool,
@@ -1474,6 +1490,12 @@ func WriteContexts(
 		return 0, err
 	}
 
+	if indexLines != nil {
+		for _, line := range indexLines {
+			indexFile.WriteString(line)
+		}
+	}
+
 	var sampledContexts chan indexContext
 
 	sampledContexts = contexts
@@ -1484,9 +1506,9 @@ func WriteContexts(
 	var target int64
 	var prevTarget int64
 	var lastPath string
-	var lastTokens int
 	var lastOffset int
 	var currentContextSize int
+	var contextIdx int
 
 	// Sometimes it is requested that we shuffle all contexts as they are
 	// written to the file. This is useful for training data, as it can help
@@ -1583,29 +1605,30 @@ func WriteContexts(
 		}
 		// Update index file
 
-		// Will keep a running total of the number of tokens in the current
-		// Index in order to write them once all contexts for that index have
-		// been written
+		// We write the index file in a way where each context represents
+		// an index into its respective tokenized file. This is useful for
+		// quickly seeking to a specific context if we wanted to.
 		if lastPath == "" {
 			lastPath = context.path
 		}
-		if lastPath == context.path {
-			// update the current context size
-			currentContextSize += lastTokens
-		} else {
-			indexFile.WriteString(
-				fmt.Sprintf("{\"path\": \"%s\", \"offset\": %d, \"tokens\": %d}\n",
-					lastPath, lastOffset, currentContextSize),
-			)
-			lastOffset += currentContextSize
-			currentContextSize = 0
-			lastPath = context.path
 
+		indexFile.WriteString(
+			fmt.Sprintf("{\"path\": \"%s\", \"offset\": %d, \"tokens\": %d, \"context_index\": %d}\n",
+				lastPath, lastOffset, currentContextSize, contextIdx),
+		)
+
+		if lastPath == context.path {
+			contextIdx += 1
+		} else {
+			contextIdx = 0
 		}
+
+		lastOffset += currentContextSize
+		currentContextSize = 0
+		lastPath = context.path
 
 		totalTokens += len(context.context)
 		endpos += len(*binContext)
-		lastTokens = len(context.context)
 
 	}
 
@@ -2033,6 +2056,7 @@ func main() {
 			var tokenizerStatus *TokenizerStatus
 			go func(threadId int) {
 				var contexts chan indexContext
+				var indexLines []string
 				var tokErr error
 				indexFilePath := fmt.Sprintf(
 					"%s.%d.index",
@@ -2042,7 +2066,7 @@ func main() {
 					"%s.%d.tokens",
 					*outputFile, threadId,
 				)
-				contexts, tokenizerStatus, tokErr = textsTokenizer.TokenizeTexts(
+				contexts, tokenizerStatus, indexLines, tokErr = textsTokenizer.TokenizeTexts(
 					textReaders,
 					indexFilePath,
 					encoder,
@@ -2056,6 +2080,7 @@ func main() {
 					strings.ReplaceAll(outputFilePath, ".tokens", ".index"),
 					contexts,
 					encoder,
+					indexLines,
 					false,
 					*enforceUint32,
 					*showContexts,
@@ -2102,6 +2127,7 @@ func main() {
 					indexFilePath,
 					contexts,
 					encoder,
+					nil,
 					false,
 					*enforceUint32,
 					*showContexts,


### PR DESCRIPTION
# Summary

While using the boundary index changes for the dataset tokenizer, we have discovered that the last rune of a context could become broken or incomplete after aligning it to a valid rune. Additionally, we require the use of a context-level index more than a document-level index. This PR introduces changes to address both of these edge cases, as well as refactoring the previous index file behavior where a race condition occurred during the index writing process. These updates are intended to be merged on top of [Rex's boundary index changes](https://github.com/wbrown/gpt_bpe/tree/rwang.boundary_index01132025).

# Changes

- Previously, the index file was being written to from two separate functions. By limiting where the index file was being written, we are able to prevent a race condition between the tokenization function and the `WriteContexts()` function. It is also important to note that this edge case only occurs with `-stream_encoding` set.
- Additional behavior has been added to the `TokenizeTextsToContexts()` function which trims broken runes from the end of tokenized chunks. The broken runes are replaced with padding tokens, which ensures valid Unicode alignment in the tokenized dataset.
- An additional `context_index` field had been introduced to the entries of our index file format to keep track of the context index for each tokenized document in a resulting dataset. This helps us quickly locate specific contexts and allows us to validate that each context is properly aligned with its specific tokenized document.

# Results

These changes have been tested with a test sample which was intentionally used to induce behavior where we would be able to see a broken rune from the dataset tokenizer.

```
एको देवः सर्वभूतेषु गूढः सर्वव्यापी सर्वभूतान्तरात्मा
कर्माध्यक्षः सर्वभूताधिवासः साक्षी चेता केवलो निर्गुणश्च
```

Originally, we had used the [Nerdstash v2 Tokenizer](https://huggingface.co/NovelAI/nerdstash-tokenizer-v2) from Anlatan to test these changes, however we were not able to reproduce the issue with the tokenizer and we had switched to using the GPT-2 tokenizer as a result which demonstrated the issue more clearly.

The resulting output that we get without the edge case fix was:

```
एको देवः सर्वभूतेषु गूढः सर्वव्यापी सर्वभूतान्तरात्मा
कर्माध्�
```

After applying the broken rune fix, we are finally left with a context that only contains valid Unicode. It is also important to note that we had used the `<|endoftext|>` token as the padding token in this case.

```
एको देवः सर्वभूतेषु गूढः सर्वव्यापी सर्वभूतान्तरात्मा
कर्माध्<|endoftext|>
```